### PR TITLE
fix dynamic queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roit/roit-data-firestore",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "main": "dist/index.js",
   "types": "src/index.ts",
   "scripts": {

--- a/src/model/QueryPredicate.ts
+++ b/src/model/QueryPredicate.ts
@@ -2,6 +2,8 @@ export class QueryPredicate {
 
     attribute: string
 
+    paramContent: string
+
     operator: string | undefined
 
     operatorKey: string

--- a/src/query/QueryPredicateFunctionTransform.ts
+++ b/src/query/QueryPredicateFunctionTransform.ts
@@ -76,12 +76,14 @@ export class QueryPredicateFunctionTransform {
 
         let functionBuilder = templateFun
 
+        const getAttribute = (queryPredicate: QueryPredicate) => queryPredicate.paramContent ?? queryPredicate.attribute 
+
         functionBuilder = functionBuilder.replace(/<repositoryClassName_value>/g, repositoryClassName)
         functionBuilder = functionBuilder.replace(/<methodSignature_value>/g, methodSignature)
-        functionBuilder = functionBuilder.replace(/<params_replace>/g, parameters.map(att => att.attribute).join(','))
-        functionBuilder = functionBuilder.replace(/<params_validator_replace>/g, parameters.filter(par => par.attribute != 'paging').map(att => `!${att.attribute}`).join('||'))
+        functionBuilder = functionBuilder.replace(/<params_replace>/g, parameters.map(att => getAttribute(att)).join(','))
+        functionBuilder = functionBuilder.replace(/<params_validator_replace>/g, parameters.filter(par => par.attribute != 'paging').map(att => `!${getAttribute(att)}`).join('||'))
         functionBuilder = functionBuilder.replace(/<collection_name_replace>/g, options.collection)
-        functionBuilder = functionBuilder.replace(/<query_predicate_replace>/g, queryPredicate.map(att => `${att.operator?.replace('ATRIBUTE', att.attribute).replace('VALUE', att.attribute)}`).join(''))
+        functionBuilder = functionBuilder.replace(/<query_predicate_replace>/g, queryPredicate.map(att => `${att.operator?.replace('ATRIBUTE', att.attribute).replace('VALUE', getAttribute(att))}`).join(''))
 
         return Function(`return ${functionBuilder}`)()
     }

--- a/src/query/TransformMethodFromQuery.ts
+++ b/src/query/TransformMethodFromQuery.ts
@@ -11,7 +11,7 @@ export class TransformMethodFromQuery {
 
         const seperadorArray = methodSignature.split('And')
 
-        const queryOperator: Array<QueryPredicate> = seperadorArray.map(part => {
+        const queryOperator: Array<QueryPredicate> = seperadorArray.map((part, index) => {
 
             const operators = Array.from(operatorMap.keys()).filter(ope => part.includes(ope))
 
@@ -21,18 +21,22 @@ export class TransformMethodFromQuery {
             const operatorConfig = operatorMap.get(operator)
 
             const predicate = new QueryPredicate
-            predicate.attribute = this.lowerCamelCase(operatorConfig?.extractOperator ? operatorConfig?.extractOperator(part) : part.replace(operator, ''))
+            const attribute = this.lowerCamelCase(operatorConfig?.extractOperator ? operatorConfig?.extractOperator(part) : part.replace(operator, ''))
+            predicate.attribute = attribute
             predicate.operator = operatorConfig?.predicate(part)
             predicate.operatorKey = operator
+            predicate.paramContent = `${attribute}${index}`
 
             return predicate
         })
 
         if (queryOptions && queryOptions.select) {
+            const selectOperator = `.select(${queryOptions.select.map(itm => `'${itm}'`).join(',')})`
             queryOperator.push({
                 attribute: 'non',
-                operator: `.select(${queryOptions.select.map(itm => `'${itm}'`).join(',')})`,
-                operatorKey: 'Select'
+                operator: selectOperator,
+                operatorKey: 'Select',
+                paramContent: selectOperator
             })
         }
 


### PR DESCRIPTION
Query of type "range" was not working because the name of the generated variable was always being the name of the attribute itself.


`@Query()
findByUpdateTimestampAtGreaterThanEqualAndUpdateTimestampAtLessThan: (first: number, second: number, paging: Paging) => Promise<ExampleModel[]>`


Before:

`[DEBUG] Executing query > .where('updateTimestampAt', '>=', updateTimestampAt).where('updateTimestampAt', '<', updateTimestampAt)`

After:

`[DEBUG] Executing query > .where('updateTimestampAt', '>=', updateTimestampAt0).where('updateTimestampAt', '<', updateTimestampAt1)`