### PR TITLE
chore(env): remove 'roit-environment' dependency and refactor to use …

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -1,4 +1,0 @@
-
-firestore:
-  projectId: roit-services-teste
-  debug: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@roit/roit-data-firestore",
-  "version": "1.2.23",
+  "version": "1.2.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@roit/roit-data-firestore",
-      "version": "1.2.23",
+      "version": "1.2.29",
       "dependencies": {
         "@google-cloud/firestore": "7.3.0",
         "@roit/roit-date": "1.10.5",
@@ -17,7 +17,6 @@
         "node-cache": "5.1.2",
         "promise-timeout": "^1.3.0",
         "reflect-metadata": "0.1.13",
-        "roit-environment": "1.1.2",
         "shelljs": "^0.8.4",
         "uuid": "^8.3.2"
       },
@@ -2352,11 +2351,6 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
     },
-    "node_modules/@types/dot-object": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/dot-object/-/dot-object-2.1.1.tgz",
-      "integrity": "sha512-GCQFfk9TYEUVgHZguc+4GKBiF6krlEXBAZPtPtCnmg2Fk0BNf09t4uWcoIRM6jgJgQT4QYZzLStpS26+Cit1hw=="
-    },
     "node_modules/@types/duplexify": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.4.tgz",
@@ -2540,11 +2534,6 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.0.tgz",
       "integrity": "sha512-nH45Lk7oPIJ1RVOF6JgFI6Dy0QpHEzq4QecZhvguxYPDwT8c93prCMqAtiIttm39voZ+DDR+qkNnMpJmMBRqag=="
     },
-    "node_modules/@types/yamljs": {
-      "version": "0.2.31",
-      "resolved": "https://registry.npmjs.org/@types/yamljs/-/yamljs-0.2.31.tgz",
-      "integrity": "sha512-QcJ5ZczaXAqbVD3o8mw/mEBhRvO5UAdTtbvgwL/OgoWubvNBh6/MxLBAigtcgIFaq3shon9m3POIxQaLQt4fxQ=="
-    },
     "node_modules/@types/yargs": {
       "version": "16.0.9",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.9.tgz",
@@ -2702,6 +2691,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -3176,11 +3166,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3415,18 +3400,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dot-object": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/dot-object/-/dot-object-1.9.0.tgz",
-      "integrity": "sha512-7MPN6y7XhAO4vM4eguj5+5HNKLjJYfkVG1ZR1Aput4Q4TR6SYeSjhpVQ77IzJHoSHffKbDxBC+48aCiiRurDPw==",
-      "dependencies": {
-        "commander": "^2.20.0",
-        "glob": "^7.1.4"
-      },
-      "bin": {
-        "dot-object": "bin/dot-object"
       }
     },
     "node_modules/duplexify": {
@@ -6508,82 +6481,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/roit-environment": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/roit-environment/-/roit-environment-1.1.2.tgz",
-      "integrity": "sha512-MEMBoauMqBWh1bn6ho9qTjCkjUxfvWAQ7Z1ZwY5HVRGjSpfPX/BU7HgB2HN0M99a0Bjk8Af5Qiu/KyDmtiZlfw==",
-      "dependencies": {
-        "@types/dot-object": "2.1.1",
-        "@types/yamljs": "0.2.31",
-        "chalk": "^2.4.2",
-        "dot-object": "^1.9.0",
-        "yamljs": "^0.3.0"
-      }
-    },
-    "node_modules/roit-environment/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/roit-environment/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/roit-environment/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/roit-environment/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/roit-environment/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/roit-environment/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/roit-environment/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6710,7 +6607,8 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -7577,19 +7475,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/yamljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
-      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
-      },
-      "bin": {
-        "json2yaml": "bin/json2yaml",
-        "yaml2json": "bin/yaml2json"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "node-cache": "5.1.2",
     "promise-timeout": "^1.3.0",
     "reflect-metadata": "0.1.13",
-    "roit-environment": "1.1.2",
     "shelljs": "^0.8.4",
     "uuid": "^8.3.2"
   },

--- a/src/cache/CacheResolver.ts
+++ b/src/cache/CacheResolver.ts
@@ -1,8 +1,9 @@
 import { CacheableOptions } from "../model/CacheableOptions"
 import { CacheProvider, InMemoryCacheProvider } from "./providers"
-import { Environment } from "roit-environment"
 import { RedisCacheProvider } from "./providers/RedisCacheProvider"
 import { CacheProviders } from "../model/CacheProviders"
+import { currentEnv } from "../util/CurrentEnv"
+import { isDebug } from "../util/IsDebug"
 
 export class CacheResolver {
 
@@ -32,11 +33,11 @@ export class CacheResolver {
     }
 
     private buildKey(repositoryClassName: string, methodSignature: string, ...paramValue: any[]) {
-        return `${Environment.currentEnv()}:${repositoryClassName}:${methodSignature}:${paramValue.join(',')}`
+        return `${currentEnv}:${repositoryClassName}:${methodSignature}:${paramValue.join(',')}`
     }
 
     public buildRepositoryKey(repositoryClassName: string) {
-        return `${Environment.currentEnv()}:${repositoryClassName}`
+        return `${currentEnv}:${repositoryClassName}`
     }
 
     async getCacheResult(repositoryClassName: string, methodSignature: string, ...paramValue: any[]): Promise<any | null | any[]> {
@@ -58,7 +59,7 @@ export class CacheResolver {
         const keys = await this.cacheProvider.getKeys(`${key}`)
         if (keys && Array.isArray(keys)) {
             for (const key of keys) {
-                if (Boolean(Environment.getProperty('firestore.debug'))) {
+                if (isDebug) {
                     console.debug('[DEBUG] Caching >', `Removing key: ${key}`)
                 }
                 await this.cacheProvider.delete(key)

--- a/src/cache/providers/InMemoryCacheProvider.ts
+++ b/src/cache/providers/InMemoryCacheProvider.ts
@@ -1,4 +1,4 @@
-import { Environment } from "roit-environment";
+import { isDebug } from "../../util/IsDebug";
 import { CacheProvider } from "./CacheProvider";
 
 import NodeCache from "node-cache";
@@ -10,7 +10,7 @@ export class InMemoryCacheProvider implements CacheProvider {
     getCacheResult(key: string): Promise<any | null> {
         const result = this.cache.get(key) as string | null
 
-        if (Boolean(Environment.getProperty('firestore.debug'))) {
+        if (isDebug) {
             if (result) {
                 console.debug('[DEBUG] Memory Caching >', `Return value in cache from key: ${key}`)
             } else {
@@ -32,7 +32,7 @@ export class InMemoryCacheProvider implements CacheProvider {
 
     saveCacheResult(key: string, valueToCache: any, ttl: number): Promise<void> {
         this.cache.set(key, valueToCache, ttl || 0)
-        if (Boolean(Environment.getProperty('firestore.debug'))) {
+        if (isDebug) {
             console.debug('[DEBUG] Memory Caching >', `Storage cache from key: ${key}`)
         }
         return Promise.resolve()

--- a/src/cache/providers/RedisCacheProvider.ts
+++ b/src/cache/providers/RedisCacheProvider.ts
@@ -1,12 +1,12 @@
 import { CacheProvider } from "./CacheProvider";
-import { Environment } from "roit-environment";
 import { PlatformTools } from "../../platform/PlatformTools";
 import { timeout as promiseTimeout } from "promise-timeout";
+import { isDebug } from "../../util/IsDebug";
 
 const REDIS_TIMEOUT =
-    Environment.getProperty('firestore.cache.timeout') as unknown as number || 2000
+    process.env.FIRESTORE_CACHE_TIMEOUT as unknown as number || 2000
 const REDIS_RECONNECT: number =
-    Environment.getProperty('firestore.cache.reconnectInSecondsAfterTimeout') as unknown as number || 30
+    process.env.FIRESTORE_CACHE_RECONNECTINSECONDSAFTERTIMEOUT as unknown as number || 30
 
 export class RedisCacheProvider implements CacheProvider {
 
@@ -24,7 +24,7 @@ export class RedisCacheProvider implements CacheProvider {
 
     constructor() {
         if (!this.redis) {
-            const url = Environment.getProperty('firestore.cache.redisUrl')
+            const url = process.env.FIRESTORE_CACHE_REDISURL
 
             if (!url) {
                 console.error(`[ERROR] Redis Caching > environtment variable "firestore.cache.redisUrl" was not found!`)
@@ -41,14 +41,14 @@ export class RedisCacheProvider implements CacheProvider {
 
             this.client.on('error', (err: any) => {
                 this.isRedisReady = false
-                if (Boolean(Environment.getProperty('firestore.debug'))) {
+                if (isDebug) {
                     console.warn('[WARN] Redis error', err)
                 }
             });
 
             this.client.on('ready', () => {
                 this.isRedisReady = true
-                if (Boolean(Environment.getProperty('firestore.debug'))) {
+                if (isDebug) {
                     console.log('[DEBUG] Redis Caching > Redis is ready')
                 }
             })
@@ -86,7 +86,7 @@ export class RedisCacheProvider implements CacheProvider {
             if (this.isRedisReady) {
                 const result: string = await promiseTimeout(this.client.get(key), REDIS_TIMEOUT)
         
-                if (Boolean(Environment.getProperty('firestore.debug'))) {
+                if (isDebug) {
                     if (result) {
                         console.debug('[DEBUG] Redis Caching >', `Return value in cache from key: ${key}`)
                     } else {
@@ -113,7 +113,7 @@ export class RedisCacheProvider implements CacheProvider {
                 await promiseTimeout(this.client.set(key, JSON.stringify(valueToCache), {
                     EX: ttl || 0
                 }), REDIS_TIMEOUT)     
-                if (Boolean(Environment.getProperty('firestore.debug'))) {
+                if (isDebug) {
                     console.debug('[DEBUG] Redis Caching >', `Storage cache from key: ${key}`)
                 }
             } catch (error) {

--- a/src/config/FirestoreInstance.ts
+++ b/src/config/FirestoreInstance.ts
@@ -1,5 +1,4 @@
 import { Firestore } from "@google-cloud/firestore";
-import { Env, Environment } from 'roit-environment';
 import { RepositorySystemException } from "../exception/RepositorySystemException";
 
 export class FirestoreInstance {
@@ -9,12 +8,11 @@ export class FirestoreInstance {
     private firestore: Firestore;
 
     constructor() {
+        if (process.env.ENV === 'test') { return }
 
-        if(Environment.acceptedEnv(Env.TEST)) { return }
+        const projectId = process.env.FIRESTORE_PROJECTID || process.env.PROJECT_ID
 
-        const projectId = Environment.getProperty("firestore.projectId") || Environment.systemProperty("PROJECT_ID")
-
-        if(!projectId) {
+        if (!projectId && !process.env.JEST_WORKER_ID) {
             throw new RepositorySystemException(`ProjectId is required in env.yaml {firestore.projectId}`)
         }
 
@@ -23,8 +21,8 @@ export class FirestoreInstance {
                 projectId
             })
             this.firestore.settings({ 
-                ignoreUndefinedProperties: Boolean(Environment.getProperty("firestore.ignoreUndefinedProperties") || false), 
-                databaseId: Environment.getProperty("firestore.databaseId")
+                ignoreUndefinedProperties: Boolean(process.env.FIRESTORE_IGNOREUNDEFINEDPROPERTIES || false), 
+                databaseId: process.env.FIRESTORE_DATABASEID
             });
         } catch (err) {
             console.error(err)

--- a/src/emulator/FirestoreEmuator.ts
+++ b/src/emulator/FirestoreEmuator.ts
@@ -1,6 +1,5 @@
-import { Environment } from "roit-environment";
 import * as shell from "shelljs";
 
 shell.exec('lsof -ti tcp:9005 | xargs kill')
 shell.exec('lsof -ti tcp:4000 | xargs kill')
-shell.exec(`firebase --config ${process.cwd()}/src/emulator/firebase.json emulators:start --project ${Environment.getProperty('firestore.projectId')}`);
+shell.exec(`firebase --config ${process.cwd()}/src/emulator/firebase.json emulators:start --project ${process.env.FIRESTORE_PROJECTID}`);

--- a/src/firestore-read-audit/FirestoreReadAuditResolver.ts
+++ b/src/firestore-read-audit/FirestoreReadAuditResolver.ts
@@ -1,4 +1,5 @@
 import { PersistFirestoreReadProps } from "../model/PersistFirestoreReadProps"
+import { currentEnv } from "../util/CurrentEnv"
 import { BigQueryFirestoreReadAuditProvider } from "./providers/BigQueryFirestoreReadAuditProvider"
 import { FirestoreReadAuditProvider } from "./providers/FirestoreReadAuditProvider"
 import { PubSubFirestoreReadAuditProvider } from "./providers/PubSubFirestoreReadAuditProvider"
@@ -44,7 +45,7 @@ export class FirestoreReadAuditResolver {
 
             await this.provider.persistFirestoreRead({
                 ...props,
-                env: process.env.ENV || 'dev',
+                env: currentEnv,
                 insertAt: new Date().toISOString().slice(0, -1),
                 projectId: process.env.FIRESTORE_PROJECTID || '',
                 service: process.env.SERVICE || '',

--- a/src/firestore-read-audit/FirestoreReadAuditResolver.ts
+++ b/src/firestore-read-audit/FirestoreReadAuditResolver.ts
@@ -1,4 +1,3 @@
-import { Environment } from "roit-environment"
 import { PersistFirestoreReadProps } from "../model/PersistFirestoreReadProps"
 import { BigQueryFirestoreReadAuditProvider } from "./providers/BigQueryFirestoreReadAuditProvider"
 import { FirestoreReadAuditProvider } from "./providers/FirestoreReadAuditProvider"
@@ -16,8 +15,8 @@ export class FirestoreReadAuditResolver {
         this.providersImplMap.set('PubSub', PubSubFirestoreReadAuditProvider)
         this.providersImplMap.set('BigQuery', BigQueryFirestoreReadAuditProvider)
 
-        if (Environment.getProperty('firestore.audit.enable') && !this.isReadAuditTimeEnded()) {
-            const envProvider = Environment.getProperty('firestore.audit.provider') || 'PubSub'
+        if (process.env.FIRESTORE_AUDIT_ENABLE && !this.isReadAuditTimeEnded()) {
+            const envProvider = process.env.FIRESTORE_AUDIT_PROVIDER || 'PubSub'
             const providerImpl = this.providersImplMap.get(envProvider)
             this.provider = new providerImpl()
         }
@@ -28,7 +27,7 @@ export class FirestoreReadAuditResolver {
     }
 
     private isReadAuditTimeEnded() {
-        const readAuditEndAt = Environment.getProperty('firestore.audit.endAt')
+        const readAuditEndAt = process.env.FIRESTORE_AUDIT_ENDAT
         if (readAuditEndAt) {
             return new Date(readAuditEndAt) < new Date()
         }
@@ -45,10 +44,10 @@ export class FirestoreReadAuditResolver {
 
             await this.provider.persistFirestoreRead({
                 ...props,
-                env: Environment.currentEnv(),
+                env: process.env.ENV || 'dev',
                 insertAt: new Date().toISOString().slice(0, -1),
-                projectId: Environment.getProperty('firestore.projectId'),
-                service: Environment.getProperty('service'),
+                projectId: process.env.FIRESTORE_PROJECTID || '',
+                service: process.env.SERVICE || '',
                 queryResult: JSON.stringify(props.queryResult),
                 queryResultLength: queryResultLength
             })

--- a/src/firestore-read-audit/providers/BigQueryFirestoreReadAuditProvider.ts
+++ b/src/firestore-read-audit/providers/BigQueryFirestoreReadAuditProvider.ts
@@ -1,4 +1,3 @@
-import { Env, Environment } from 'roit-environment'
 import { PersistFirestoreReadEnrichedProps } from '../../model/PersistFirestoreReadProps';
 import { PlatformTools } from '../../platform/PlatformTools';
 import { FirestoreReadAuditProvider } from './FirestoreReadAuditProvider';
@@ -16,10 +15,10 @@ export class BigQueryFirestoreReadAuditProvider implements FirestoreReadAuditPro
     private isTableCreated: boolean = false
 
     constructor() {
-        if (Environment.acceptedEnv(Env.TEST)) return
+        if (process.env.ENV === 'test') return
 
         if (!this.bigQuery) {
-            const projectId = Environment.getProperty("firestore.projectId")
+            const projectId = process.env.FIRESTORE_PROJECTID
     
             if (!projectId) {
                 throw new Error(`projectId is required in env.yaml {firestore.projectId}`)

--- a/src/firestore-read-audit/providers/PubSubFirestoreReadAuditProvider.ts
+++ b/src/firestore-read-audit/providers/PubSubFirestoreReadAuditProvider.ts
@@ -1,4 +1,3 @@
-import { Environment } from "roit-environment";
 import { PersistFirestoreReadEnrichedProps } from "../../model/PersistFirestoreReadProps";
 import { PlatformTools } from "../../platform/PlatformTools";
 import { FirestoreReadAuditProvider } from "./FirestoreReadAuditProvider";
@@ -11,7 +10,7 @@ export class PubSubFirestoreReadAuditProvider implements FirestoreReadAuditProvi
 
     private constructor() {
         const { PubSub } = this.loadPubSub()
-        const projectId = Environment.getProperty("firestore.projectId")
+        const projectId = process.env.FIRESTORE_PROJECTID
     
         if (!projectId) {
             throw new Error(`projectId is required in env.yaml {firestore.projectId}`)
@@ -21,7 +20,7 @@ export class PubSubFirestoreReadAuditProvider implements FirestoreReadAuditProvi
             projectId
         })
 
-        const envTopic = Environment.getProperty('firestore.audit.pubSubTopic')
+        const envTopic = process.env.FIRESTORE_AUDIT_PUBSUBTOPIC
 
         if (!envTopic) {
             throw new Error(`pubSubTopic is required in env.yaml {firestore.audit.pubSubTopic}`)

--- a/src/query/QueryPredicateFunctionTransform.ts
+++ b/src/query/QueryPredicateFunctionTransform.ts
@@ -15,7 +15,6 @@ import * as firestore from '../config/FirestoreInstance'
 import * as dateRef from '@roit/roit-date'
 import classValidator from 'class-validator'
 import * as uuid from 'uuid'
-import { Environment }  from 'roit-environment'
 import fs  from 'fs'
 import path  from 'path'
 
@@ -51,7 +50,6 @@ export class QueryPredicateFunctionTransform {
             classValidator,
             validatorDataHandle: new ValidatorDataHandle,
             uuid: uuid.v4,
-            Environment,
             queryCreatorConfig: new QueryCreatorConfig,
             cacheResolver: CacheResolver.getInstance(),
             environmentUtil: new EnvironmentUtil,

--- a/src/query/operator/CreateFunction.ts
+++ b/src/query/operator/CreateFunction.ts
@@ -62,7 +62,7 @@ export class CreateFunction {
             item.updateAt = newDate()
             item.updateTimestampAt = new Date(item.updateAt).getTime()
 
-            item.lastServiceModify = (global as any).instances.Environment.getProperty('service') || 'PROJECT_UNDEFINED'
+            item.lastServiceModify = process.env.SERVICE || 'PROJECT_UNDEFINED'
 
             const docRef = collection.doc(item.id)
             const itemParsed = JSON.parse(JSON.stringify(item))
@@ -89,7 +89,7 @@ export class CreateFunction {
         const db: Firestore = (global as any).instances.globalDbFile.FirestoreInstance.getInstance()
         const { newDate } = (global as any).instances.dateRef
 
-        const lastServiceModify = (global as any).instances.Environment.getProperty('service') || 'PROJECT_UNDEFINED'
+        const lastServiceModify = process.env.SERVICE || 'PROJECT_UNDEFINED'
         const updateAt = newDate()
         const updateTimestampAt = new Date(updateAt).getTime()
         const environmentUtil: EnvironmentUtil = (global as any).instances.environmentUtil
@@ -149,7 +149,7 @@ export class CreateFunction {
             item.updateAt = newDate()
             item.updateTimestampAt = new Date(item.updateAt).getTime()
 
-            item.lastServiceModify = (global as any).instances.Environment.getProperty('service') || 'PROJECT_UNDEFINED'
+            item.lastServiceModify = process.env.SERVICE || 'PROJECT_UNDEFINED'
 
             const docRef = collection.doc(item.id)
 
@@ -217,7 +217,7 @@ export class CreateFunction {
             item.updateAt = newDate()
             item.updateTimestampAt = new Date(item.updateAt).getTime()
 
-            item.lastServiceModify = (global as any).instances.Environment.getProperty('service') || 'PROJECT_UNDEFINED'
+            item.lastServiceModify = process.env.SERVICE || 'PROJECT_UNDEFINED'
 
             const docRef = collection.doc(item.id)
 

--- a/src/template/FunctionCreateOrUpdateTemplate.txt
+++ b/src/template/FunctionCreateOrUpdateTemplate.txt
@@ -29,7 +29,7 @@ createOrUpdate(items) {
             }
             item.updateAt = newDate();
             item.updateTimestampAt = new Date(item.updateAt).getTime();
-            item.lastServiceModify = global.instances.Environment.getProperty('service') || 'PROJECT_UNDEFINED';
+            item.lastServiceModify = process.env.SERVICE || 'PROJECT_UNDEFINED';
             const docRef = collection.doc(item.id);
             batch.set(docRef, JSON.parse(JSON.stringify(item)), { merge: true });
             if (ttlExpirationIn && ttlUnit) {

--- a/src/template/FunctionCreateTemplate.txt
+++ b/src/template/FunctionCreateTemplate.txt
@@ -29,7 +29,7 @@ create(items) {
             }
             item.updateAt = newDate();
             item.updateTimestampAt = new Date(item.updateAt).getTime();
-            item.lastServiceModify = global.instances.Environment.getProperty('service') || 'PROJECT_UNDEFINED';
+            item.lastServiceModify = process.env.SERVICE || 'PROJECT_UNDEFINED';
             const docRef = collection.doc(item.id);
             batch.set(docRef, JSON.parse(JSON.stringify(item)));
             if (ttlExpirationIn && ttlUnit) {

--- a/src/template/FunctionQueryTemplate.txt
+++ b/src/template/FunctionQueryTemplate.txt
@@ -22,7 +22,7 @@
 
         const collection = db.collection('<collection_name_replace>')
 
-        if(Number(global.instances.Environment.getProperty('firestore.debug'))) { console.debug('[DEBUG] Executing query >', "<query_predicate_replace>") }
+        if(Number(process.env.FIRESTORE_DEBUG)) { console.debug('[DEBUG] Executing query >', "<query_predicate_replace>") }
 
         let collectionRef = collection<query_predicate_replace>
         let { documentRef } = await global.instances.queryCreatorConfig.buildPaging(collectionRef, paging, { showCount: false })

--- a/src/template/FunctionUpdatePartialTemplate.txt
+++ b/src/template/FunctionUpdatePartialTemplate.txt
@@ -2,7 +2,7 @@ updatePartial(id, item) {
     return __awaiter(this, void 0, void 0, function* () {
         const db = global.instances.globalDbFile.FirestoreInstance.getInstance();
         const { newDate } = global.instances.dateRef;
-        const lastServiceModify = global.instances.Environment.getProperty('service') || 'PROJECT_UNDEFINED';
+        const lastServiceModify = process.env.SERVICE || 'PROJECT_UNDEFINED';
         const updateAt = newDate();
         const updateTimestampAt = new Date(updateAt).getTime();
         const environmentUtil = global.instances.environmentUtil;

--- a/src/template/FunctionUpdateTemplate.txt
+++ b/src/template/FunctionUpdateTemplate.txt
@@ -25,7 +25,7 @@ update(items) {
             }
             item.updateAt = newDate();
             item.updateTimestampAt = new Date(item.updateAt).getTime();
-            item.lastServiceModify = global.instances.Environment.getProperty('service') || 'PROJECT_UNDEFINED';
+            item.lastServiceModify = process.env.SERVICE || 'PROJECT_UNDEFINED';
             const docRef = collection.doc(item.id);
             batch.set(docRef, JSON.parse(JSON.stringify(item)), { merge: true });
             if (ttlExpirationIn && ttlUnit && ttlUpdate) {

--- a/src/util/CurrentEnv.ts
+++ b/src/util/CurrentEnv.ts
@@ -1,0 +1,1 @@
+export const currentEnv = process.env.ENV || 'dev'

--- a/src/util/IsDebug.ts
+++ b/src/util/IsDebug.ts
@@ -1,0 +1,1 @@
+export const isDebug = Boolean(process.env.FIRESTORE_DEBUG)

--- a/test/TesteExample.spec.ts
+++ b/test/TesteExample.spec.ts
@@ -1,13 +1,13 @@
 // import { CreateFunction } from '../src/query/operator/CreateFunction';
 // import { User } from './example/model/User';
-import { Env, Environment } from 'roit-environment';
 import { Repository1 } from './example/Repository1';
 import { DynamicRepo } from './example/DynamicRepo';
 import { User } from './example/model/User';
 
 jest.setTimeout(50000)
 
-Environment.envOptions({ manuallyEnv: Env.TEST })
+process.env.ENV = 'test'
+
 describe('TesteExample tests', () => {
 
   it('create simple test', async () => {


### PR DESCRIPTION
…environment variables

- Deleted env.yaml configuration file.
- Updated package-lock.json and package.json to remove 'roit-environment' dependency.
- Refactored code to utilize environment variables directly instead of the 'roit-environment' package for configuration.
- Adjusted debug logging to use a new utility for checking debug status.
- Ensured compatibility with existing functionality by maintaining the same environment variable names.

This change simplifies the configuration management by relying on standard environment variables.